### PR TITLE
Handle empty string in ACSV::Detect.separator

### DIFF
--- a/lib/acsv/detect/separator.rb
+++ b/lib/acsv/detect/separator.rb
@@ -13,8 +13,11 @@ module ACSV
         firstline = file_or_data.readline
         file_or_data.seek(position)
       else
+        return nil if file_or_data.empty?
+
         firstline = file_or_data.split("\n", 2)[0]
       end
+
       separators = SEPARATORS.map{|s| s.encode(firstline.encoding)}
       sep = separators.map {|x| [firstline.count(x),x]}.sort_by {|x| x[0]}.last
       sep[0] == 0 ? nil : sep[1].encode('ascii')

--- a/spec/acsv/separator_spec.rb
+++ b/spec/acsv/separator_spec.rb
@@ -22,5 +22,8 @@ describe ACSV::Detect do
       end
     end
 
+    it 'handles empty string' do
+      expect(ACSV::Detect.separator('')).to be_nil
+    end
   end
 end


### PR DESCRIPTION
Now `ACSV::Detect.separator('')` fails with error
```
NoMethodError: undefined method 'encoding' for nil:NilClass
```
This pr fixes it, returning `nil` for empty string.