### PR TITLE
separate positional and keyword args (ruby 3)

### DIFF
--- a/lib/acsv/csv.rb
+++ b/lib/acsv/csv.rb
@@ -15,7 +15,7 @@ module ACSV
     # @see http://www.ruby-doc.org/stdlib/libdoc/csv/rdoc/CSV.html#method-c-new
     def initialize(data, options = Hash.new)
       options[:col_sep] ||= ACSV::Detect.separator(data)
-      super(data, options)
+      super(data, **options)
     end
 
     # This method opens an IO object, and wraps that with CSV. For reading, separator


### PR DESCRIPTION
Hi,

The current code is not compatible with ruby 3 but this simple fixes it.

see https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0